### PR TITLE
adding new_field (testing PR behavior on git mv)

### DIFF
--- a/builtin/providers/hashicorp/aws/resource_aws_instance.go
+++ b/builtin/providers/hashicorp/aws/resource_aws_instance.go
@@ -35,6 +35,12 @@ func resourceAwsInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"new_field": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
 			"associate_public_ip_address": &schema.Schema{
 				Type:     schema.TypeBool,
 				ForceNew: true,

--- a/builtin/providers/hashicorp/aws/resource_aws_instance_test.go
+++ b/builtin/providers/hashicorp/aws/resource_aws_instance_test.go
@@ -459,6 +459,10 @@ func TestAccAWSInstance_associatePublicIPAndPrivateIP(t *testing.T) {
 	})
 }
 
+func TestAccNewTest(t *testing.T) {
+	// some tests
+}
+
 // Guard against regression with KeyPairs
 // https://github.com/hashicorp/terraform/issues/2302
 func TestAccAWSInstance_keyPairCheck(t *testing.T) {


### PR DESCRIPTION
```
❯ git rebase master
First, rewinding head to replay your work on top of it...
Applying: adding new_field (testing PR behavior on git mv)
Using index info to reconstruct a base tree...
A       builtin/providers/aws/resource_aws_instance.go
A       builtin/providers/aws/resource_aws_instance_test.go
Falling back to patching base and 3-way merge...
Auto-merging builtin/providers/hashicorp/aws/resource_aws_instance_test.go
Auto-merging builtin/providers/hashicorp/aws/resource_aws_instance.go
```
